### PR TITLE
Add helm chart directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# newrelic.com/newrelic-operator-bundle:$VERSION and newrelic.com/newrelic-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= newrelic.com/newrelic-operator
+# newrelic.com/newrelic-k8s-operator-bundle:$VERSION and newrelic.com/newrelic-k8s-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= newrelic.com/newrelic-k8s-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -137,7 +137,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	kubectl create namespace newrelic-operator-system	
+	kubectl create namespace newrelic-k8s-operator-system	
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
@@ -146,13 +146,13 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-	kubectl delete namespace newrelic-operator-system
+	kubectl delete namespace newrelic-k8s-operator-system
 
 .PHONY: helm
 helm: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/crd > charts/newrelic-k8s-operator/crds/nr_crd.yaml
-	$(KUSTOMIZE) build config/default | sed 's/newrelic-operator-system/{{.Release.Namespace}}/g' > charts/newrelic-k8s-operator/templates/operator.yaml
+	$(KUSTOMIZE) build config/default | sed 's/newrelic-k8s-operator-system/{{.Release.Namespace}}/g' > charts/newrelic-k8s-operator/templates/operator.yaml
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# newrelic.com/newrelic-k8s-operator-bundle:$VERSION and newrelic.com/newrelic-k8s-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= newrelic.com/newrelic-k8s-operator
+# newrelic.com/newrelic-operator-bundle:$VERSION and newrelic.com/newrelic-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= newrelic.com/newrelic-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -87,7 +87,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	#$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -136,12 +137,22 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	kubectl create namespace newrelic-operator-system	
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	kubectl delete namespace newrelic-operator-system
+
+.PHONY: helm
+helm: manifests kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/crd > charts/newrelic-k8s-operator/crds/nr_crd.yaml
+	$(KUSTOMIZE) build config/default | sed 's/newrelic-operator-system/{{.Release.Namespace}}/g' > charts/newrelic-k8s-operator/templates/operator.yaml
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# newrelic.com/newrelic-k8s-operator-bundle:$VERSION and newrelic.com/newrelic-k8s-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= newrelic.com/newrelic-k8s-operator
+# newrelic.com/newrelic-k8s-operator-bundle:$VERSION and newrelic/newrelic-k8s-operator-catalog:$VERSION.
+IMAGE_TAG_BASE ?= newrelic/newrelic-k8s-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/charts/newrelic-k8s-operator/.helmignore
+++ b/charts/newrelic-k8s-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/newrelic-k8s-operator/Chart.yaml
+++ b/charts/newrelic-k8s-operator/Chart.yaml
@@ -31,6 +31,8 @@ maintainers:
     url: https://github.com/aimichelle
   - name: htroisi
     url: https://github.com/htroisi
+  - name: vihangm
+    url: https://github.com/vihangm
 
 keywords:
   - infrastructure

--- a/charts/newrelic-k8s-operator/Chart.yaml
+++ b/charts/newrelic-k8s-operator/Chart.yaml
@@ -1,0 +1,38 @@
+apiVersion: v2
+name: newrelic-k8s-operator
+description: A Helm chart for New Relic's Kubernetes operator. 
+home: https://github.com/newrelic/newrelic-k8s-operator
+icon: https://newrelic.com/assets/newrelic/source/NewRelic-logo-square.svg
+sources:
+  - https://github.com/newrelic/newrelic-k8s-operator/
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"
+
+maintainers:
+  - name: aimichelle 
+    url: https://github.com/aimichelle
+  - name: htroisi
+    url: https://github.com/htroisi
+
+keywords:
+  - infrastructure
+  - newrelic
+  - monitoring

--- a/charts/newrelic-k8s-operator/README.md.gotmpl
+++ b/charts/newrelic-k8s-operator/README.md.gotmpl
@@ -1,0 +1,36 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+# Helm installation
+
+You can install this chart using directly from this repository or by adding the Helm repository:
+
+```shell
+helm repo add newrelic https://helm-charts.newrelic.com && helm repo update
+helm upgrade --install newrelic/newrelic-k8s-operator -f your-custom-values.yaml
+```
+
+{{ template "chart.sourcesSection" . }}
+
+## Values
+
+The values for the chart follow the values in the [nri-bundle chart](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle).
+
+{{ if .Maintainers }}
+## Maintainers
+{{ range .Maintainers }}
+{{- if .Name }}
+{{- if .Url }}
+* [{{ .Name }}]({{ .Url }})
+{{- else }}
+* {{ .Name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/newrelic-k8s-operator/crds/nr_crd.yaml
+++ b/charts/newrelic-k8s-operator/crds/nr_crd.yaml
@@ -1,0 +1,98 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: newrelics.newrelic.newrelic.com
+spec:
+  group: newrelic.newrelic.com
+  names:
+    kind: NewRelic
+    listKind: NewRelicList
+    plural: newrelics
+    singular: newrelic
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NewRelic is the Schema for the newrelics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NewRelicSpec defines the desired state of NewRelic
+            properties:
+              version:
+                description: Version is the version of nri-bundle that should be deployed.
+                type: string
+            type: object
+          status:
+            description: NewRelicStatus defines the observed state of NewRelic
+            properties:
+              version:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nribundles.newrelic.newrelic.com
+spec:
+  group: newrelic.newrelic.com
+  names:
+    kind: NRIBundle
+    listKind: NRIBundleList
+    plural: nribundles
+    singular: nribundle
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NRIBundle is the Schema for the nribundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of NRIBundle
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of NRIBundle
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/newrelic-k8s-operator/templates/newrelic.yaml
+++ b/charts/newrelic-k8s-operator/templates/newrelic.yaml
@@ -1,0 +1,5 @@
+apiVersion: newrelic.newrelic.com/v1alpha1
+kind: NewRelic
+metadata:
+  name: newrelic
+spec:

--- a/charts/newrelic-k8s-operator/templates/nribundle.yaml
+++ b/charts/newrelic-k8s-operator/templates/nribundle.yaml
@@ -1,0 +1,7 @@
+apiVersion: newrelic.newrelic.com/v1alpha1
+kind: NRIBundle
+metadata:
+  name: nribundle
+  namespace: {{.Release.Namespace}}
+spec:
+{{ toYaml .Values | indent 2 }}

--- a/charts/newrelic-k8s-operator/templates/operator.yaml
+++ b/charts/newrelic-k8s-operator/templates/operator.yaml
@@ -1,0 +1,504 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-controller-manager
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-leader-election-role
+  namespace: {{.Release.Namespace}}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: newrelic-operator-manager-role
+rules:
+- apiGroups:
+  - newrelic.newrelic.com
+  resources:
+  - newrelics
+  - nribundles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - newrelic.newrelic.com
+  resources:
+  - newrelics/finalizers
+  - nribundles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - newrelic.newrelic.com
+  resources:
+  - newrelics/status
+  - nribundles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - create
+  - list
+  - update
+  - patch
+  - delete
+  - watch
+- apiGroups:
+  - px.dev
+  resources:
+  - viziers
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - catalogsources
+  - subscriptions
+  - installplans
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - list
+  - delete
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - charts.newrelic.com
+  resources:
+  - newrelics
+  - newrelics/status
+  - newrelics/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - apps
+  - rbac.authorization.k8s.io
+  - extensions
+  - etcd.database.coreos.com
+  - batch
+  - nats.io
+  - policy
+  - apiextensions.k8s.io
+  - px.dev
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - configmaps
+  - customresourcedefinitions
+  - secrets
+  - pods
+  - events
+  - services
+  - deployments
+  - daemonsets
+  - nodes
+  - persistentvolumes
+  - persistentvolumeclaims
+  - roles
+  - rolebindings
+  - serviceaccounts
+  - etcdclusters
+  - statefulsets
+  - cronjobs
+  - jobs
+  - natsclusters
+  - poddisruptionbudgets
+  - viziers
+  - viziers/status
+  - podsecuritypolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  - ""
+  resources:
+  - storageclasses
+  - namespaces
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-leader-election-rolebinding
+  namespace: {{.Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: newrelic-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: newrelic-operator-controller-manager
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: newrelic-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: newrelic-operator-controller-manager
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: newrelic-operator
+  name: newrelic-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: newrelic-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: newrelic-operator-controller-manager
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: newrelic-operator
+    control-plane: controller-manager
+  name: newrelic-operator-controller-manager-metrics-service
+  namespace: {{.Release.Namespace}}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: newrelic-operator
+    control-plane: controller-manager
+  name: newrelic-operator-controller-manager
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        - --leader-election-id=newrelic-operator
+        image: controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: newrelic-operator-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/newrelic-k8s-operator/values.yaml
+++ b/charts/newrelic-k8s-operator/values.yaml
@@ -1,0 +1,163 @@
+newrelic-infrastructure:
+  # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
+  enabled: true
+
+nri-prometheus:
+  # nri-prometheus.enabled -- Install the [`nri-prometheus` chart](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
+  enabled: false
+
+nri-metadata-injection:
+  # nri-metadata-injection.enabled -- Install the [`nri-metadata-injection` chart](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection)
+  enabled: true
+
+kube-state-metrics:
+  # kube-state-metrics.enabled -- Install the [`kube-state-metrics` chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) from the stable helm charts repository.
+  # This is mandatory if `infrastructure.enabled` is set to `true` and the user does not provide its own instance of KSM version >=1.8 and <=2.0
+  enabled: false
+
+nri-kube-events:
+  # nri-kube-events.enabled -- Install the [`nri-kube-events` chart](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
+  enabled: false
+
+newrelic-logging:
+  # newrelic-logging.enabled -- Install the [`newrelic-logging` chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
+  enabled: false
+
+newrelic-pixie:
+  # newrelic-pixie.enabled -- Install the [`newrelic-pixie`](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie)
+  enabled: false
+
+pixie-chart:
+  # pixie-chart.enabled -- Install the [`pixie-chart` chart](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy)
+  enabled: false
+
+newrelic-infra-operator:
+  # newrelic-infra-operator.enabled -- Install the [`newrelic-infra-operator` chart](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator) (Beta)
+  enabled: false
+
+newrelic-prometheus-agent:
+  # newrelic-prometheus-agent.enabled -- Install the [`newrelic-prometheus-agent` chart](https://github.com/newrelic/newrelic-prometheus-configurator/tree/main/charts/newrelic-prometheus-agent)
+  enabled: false
+
+newrelic-k8s-metrics-adapter:
+  # newrelic-k8s-metrics-adapter.enabled -- Install the [`newrelic-k8s-metrics-adapter.` chart](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter) (Beta)
+  enabled: false
+
+
+# -- change the behaviour globally to all the supported helm charts.
+# See [user's guide of the common library](https://github.com/newrelic/helm-charts/blob/master/library/common-library/README.md) for further information.
+# @default -- See [`values.yaml`](values.yaml)
+global:
+  # -- The cluster name for the Kubernetes cluster.
+  cluster: ""
+
+  # -- The license key for your New Relic Account. This will be preferred configuration option if both `licenseKey` and `customSecret` are specified.
+  licenseKey: ""
+  # -- The license key for your New Relic Account. This will be preferred configuration option if both `insightsKey` and `customSecret` are specified.
+  insightsKey: ""
+  # -- Name of the Secret object where the license key is stored
+  customSecretName: ""
+  # -- Key in the Secret object where the license key is stored
+  customSecretLicenseKey: ""
+
+  # -- Additional labels for chart objects
+  labels: {}
+  # -- Additional labels for chart pods
+  podLabels: {}
+
+  images:
+    # -- Changes the registry where to get the images. Useful when there is an internal image cache/proxy
+    registry: ""
+    # -- Set secrets to be able to fetch images
+    pullSecrets: []
+
+  serviceAccount:
+    # -- Add these annotations to the service account we create
+    annotations: {}
+    # -- Configures if the service account should be created or not
+    create:
+    # -- Change the name of the service account. This is honored if you disable on this chart the creation of the service account so you can use your own
+    name:
+
+  # -- (bool) Sets pod's hostNetwork
+  # @default -- false
+  hostNetwork:
+  # -- Sets pod's dnsConfig
+  dnsConfig: {}
+
+  # -- Sets pod's priorityClassName
+  priorityClassName: ""
+  # -- Sets security context (at pod level)
+  podSecurityContext: {}
+  # -- Sets security context (at container level)
+  containerSecurityContext: {}
+
+  # -- Sets pod/node affinities
+  affinity: {}
+  # -- Sets pod's node selector
+  nodeSelector: {}
+  # -- Sets pod's tolerations to node taints
+  tolerations: []
+
+  # -- Adds extra attributes to the cluster and all the metrics emitted to the backend
+  customAttributes: {}
+
+  # -- (bool) Reduces number of metrics sent in order to reduce costs
+  # @default -- false
+  lowDataMode:
+
+  # -- (bool) In each integration it has different behavior. See [Further information](#values-managed-globally-3) but all aims to send less metrics to the backend to try to save costs |
+  # @default -- false
+  privileged:
+
+  # -- (bool) Must be set to `true` when deploying in an EKS Fargate environment
+  # @default -- false
+  fargate:
+
+  # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`
+  proxy: ""
+
+  # -- (bool) Send the metrics to the staging backend. Requires a valid staging license key
+  # @default -- false
+  nrStaging:
+  fedramp:
+    # fedramp.enabled -- (bool) Enables FedRAMP
+    # @default -- false
+    enabled:
+
+  # -- (bool) Sets the debug logs to this integration or all integrations if it is set globally
+  # @default -- false
+  verboseLog:
+
+
+# To add values to the subcharts. Follow Helm's guide: https://helm.sh/docs/chart_template_guide/subcharts_and_globals
+
+# If you wish to monitor services running on Kubernetes you can provide integrations
+# configuration under `integrations_config` that it will passed down to the `newrelic-infrastructure` chart.
+#
+# You just need to create a new entry where the "name" is the filename of the configuration file and the data is the content of
+# the integration configuration. The name must end in ".yaml" as this will be the
+# filename generated and the Infrastructure agent only looks for YAML files.
+#
+# The data part is the actual integration configuration as described in the spec here:
+# https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
+#
+# In the following example you can see how to monitor a Redis integration with autodiscovery
+#
+#
+# newrelic-infrastructure:
+#   integrations:
+#     nri-redis-sampleapp:
+#       discovery:
+#         command:
+#           exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+#           match:
+#             label.app: sampleapp
+#       integrations:
+#         - name: nri-redis
+#           env:
+#             # using the discovered IP as the hostname address
+#             HOSTNAME: ${discovery.ip}
+#             PORT: 6379
+#           labels:
+#             env: test


### PR DESCRIPTION
This adds the operator's helm chart directory.
The helm chart CRDs/templates can be updated using the changes included in the `Makefile`.