### PR TITLE
Update CRDs in helm chart

### DIFF
--- a/charts/newrelic-k8s-operator/crds/nr_crd.yaml
+++ b/charts/newrelic-k8s-operator/crds/nr_crd.yaml
@@ -4,20 +4,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
-  name: newrelics.newrelic.newrelic.com
+  name: monitors.newrelic.com
 spec:
-  group: newrelic.newrelic.com
+  group: newrelic.com
   names:
-    kind: NewRelic
-    listKind: NewRelicList
-    plural: newrelics
-    singular: newrelic
+    kind: Monitor
+    listKind: MonitorList
+    plural: monitors
+    singular: monitor
   scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NewRelic is the Schema for the newrelics API
+        description: Monitor is the Schema for the monitors API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,14 +32,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: NewRelicSpec defines the desired state of NewRelic
+            description: MonitorSpec defines the desired state of Monitor
             properties:
               version:
                 description: Version is the version of nri-bundle that should be deployed.
                 type: string
             type: object
           status:
-            description: NewRelicStatus defines the observed state of NewRelic
+            description: MonitorStatus defines the observed state of Monitor
             properties:
               version:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
@@ -56,9 +56,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: nribundles.newrelic.newrelic.com
+  name: nribundles.newrelic.com
 spec:
-  group: newrelic.newrelic.com
+  group: newrelic.com
   names:
     kind: NRIBundle
     listKind: NRIBundleList

--- a/charts/newrelic-k8s-operator/templates/operator.yaml
+++ b/charts/newrelic-k8s-operator/templates/operator.yaml
@@ -1,14 +1,113 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: monitors.newrelic.com
+spec:
+  group: newrelic.com
+  names:
+    kind: Monitor
+    listKind: MonitorList
+    plural: monitors
+    singular: monitor
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Monitor is the Schema for the monitors API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MonitorSpec defines the desired state of Monitor
+            properties:
+              version:
+                description: Version is the version of nri-bundle that should be deployed.
+                type: string
+            type: object
+          status:
+            description: MonitorStatus defines the observed state of Monitor
+            properties:
+              version:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nribundles.newrelic.com
+spec:
+  group: newrelic.com
+  names:
+    kind: NRIBundle
+    listKind: NRIBundleList
+    plural: nribundles
+    singular: nribundle
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NRIBundle is the Schema for the nribundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of NRIBundle
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of NRIBundle
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-controller-manager
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-controller-manager
   namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,12 +115,12 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: role
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-leader-election-role
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-leader-election-role
   namespace: {{.Release.Namespace}}
 rules:
 - apiGroups:
@@ -60,12 +159,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: newrelic-operator-manager-role
+  name: newrelic-k8s-operator-manager-role
 rules:
 - apiGroups:
-  - newrelic.newrelic.com
+  - newrelic.com
   resources:
-  - newrelics
+  - monitors
   - nribundles
   verbs:
   - create
@@ -76,16 +175,16 @@ rules:
   - update
   - watch
 - apiGroups:
-  - newrelic.newrelic.com
+  - newrelic.com
   resources:
-  - newrelics/finalizers
+  - monitors/finalizers
   - nribundles/finalizers
   verbs:
   - update
 - apiGroups:
-  - newrelic.newrelic.com
+  - newrelic.com
   resources:
-  - newrelics/status
+  - monitors/status
   - nribundles/status
   verbs:
   - get
@@ -166,20 +265,6 @@ rules:
   - delete
   - update
   - patch
-  - watch
-- apiGroups:
-  - charts.newrelic.com
-  resources:
-  - newrelics
-  - newrelics/status
-  - newrelics/finalizers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -282,12 +367,12 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-metrics-reader
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -299,12 +384,12 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-proxy-role
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -324,20 +409,20 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-leader-election-rolebinding
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-leader-election-rolebinding
   namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: newrelic-operator-leader-election-role
+  name: newrelic-k8s-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: newrelic-operator-controller-manager
+  name: newrelic-k8s-operator-controller-manager
   namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -345,19 +430,19 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-manager-rolebinding
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: newrelic-operator-manager-role
+  name: newrelic-k8s-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: newrelic-operator-controller-manager
+  name: newrelic-k8s-operator-controller-manager
   namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -365,19 +450,19 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: newrelic-operator
-  name: newrelic-operator-proxy-rolebinding
+    app.kubernetes.io/part-of: newrelic-k8s-operator
+  name: newrelic-k8s-operator-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: newrelic-operator-proxy-role
+  name: newrelic-k8s-operator-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: newrelic-operator-controller-manager
+  name: newrelic-k8s-operator-controller-manager
   namespace: {{.Release.Namespace}}
 ---
 apiVersion: v1
@@ -385,13 +470,13 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: newrelic-operator
+    app.kubernetes.io/part-of: newrelic-k8s-operator
     control-plane: controller-manager
-  name: newrelic-operator-controller-manager-metrics-service
+  name: newrelic-k8s-operator-controller-manager-metrics-service
   namespace: {{.Release.Namespace}}
 spec:
   ports:
@@ -407,13 +492,13 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: newrelic-operator
+    app.kubernetes.io/created-by: newrelic-k8s-operator
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/part-of: newrelic-operator
+    app.kubernetes.io/part-of: newrelic-k8s-operator
     control-plane: controller-manager
-  name: newrelic-operator-controller-manager
+  name: newrelic-k8s-operator-controller-manager
   namespace: {{.Release.Namespace}}
 spec:
   replicas: 1
@@ -471,7 +556,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --leader-election-id=newrelic-operator
+        - --leader-election-id=newrelic-k8s-operator
         image: controller:latest
         livenessProbe:
           httpGet:
@@ -500,5 +585,5 @@ spec:
             - ALL
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: newrelic-operator-controller-manager
+      serviceAccountName: newrelic-k8s-operator-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
We renamed a few of the CRDs/group in a previous PR, which made the CRDs included in the helm chart out-of-date.
This was generated by running `make helm` which kustomizes the CRD, then copies it to the helm chart.

Alternatively, it may be possible to just add this step to the release build itself.