### PR TITLE
Add version to template for Monitor resource

### DIFF
--- a/charts/newrelic-k8s-operator/Chart.yaml
+++ b/charts/newrelic-k8s-operator/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the

--- a/charts/newrelic-k8s-operator/templates/newrelic.yaml
+++ b/charts/newrelic-k8s-operator/templates/newrelic.yaml
@@ -3,3 +3,4 @@ kind: Monitor
 metadata:
   name: newrelic
 spec:
+  version: {{.Values.version}}

--- a/charts/newrelic-k8s-operator/values.yaml
+++ b/charts/newrelic-k8s-operator/values.yaml
@@ -1,3 +1,4 @@
+version: ""
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true


### PR DESCRIPTION
Users may want to specify a specific version for nri-bundle at deploy time, rather than always selecting latest.