### PR TITLE
fix: Update helm upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can install this chart using directly from this repository or by adding the 
 
 ```shell
 helm repo add nr-operator https://newrelic.github.io/newrelic-k8s-operator && helm repo update
-helm upgrade --install nr-operator/newrelic-k8s-operator -f your-custom-values.yaml
+helm upgrade --install nr-operator nr-operator/newrelic-k8s-operator -f your-custom-values.yaml
 ```
 
 For further information of the configuration needed for the chart, you can follow the configuration specified in the [nri-bundle chart](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle). Please make sure `global.licenseKey` is specified.


### PR DESCRIPTION
Missing release name for `helm upgrade --install` command.  Without it, it throws an error.

```
$ helm upgrade --install nr-operator/newrelic-k8s-operator -f values.yaml -n newrelic
Error: "helm upgrade" requires 2 arguments

Usage:  helm upgrade [RELEASE] [CHART] [flags]
```