### PR TITLE
Add Helm schema json files

### DIFF
--- a/charts/newrelic-k8s-operator/aws_mp_configuration_schema.json
+++ b/charts/newrelic-k8s-operator/aws_mp_configuration_schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "required": [
+        "global"
+    ],
+    "properties": {
+        "global": {
+            "type": "object",
+            "required": [
+                "licenseKey"
+            ],
+            "properties": {
+                "licenseKey": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/charts/newrelic-k8s-operator/values.schema.json
+++ b/charts/newrelic-k8s-operator/values.schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "required": [
+        "global"
+    ],
+    "properties": {
+        "global": {
+            "type": "object",
+            "required": [
+                "licenseKey"
+            ],
+            "properties": {
+                "licenseKey": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We want to add the newrelic-k8s-operator to the AWS Marketplace. As a part of that work, we need to include the AWS-specific values.schema.json file. 
This file is used in Helm to apply any constraints (such as required fields) to the values users can pass in.