### PR TITLE
Allow licenseKey to be specified in secret

### DIFF
--- a/charts/newrelic-k8s-operator/Chart.yaml
+++ b/charts/newrelic-k8s-operator/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the

--- a/charts/newrelic-k8s-operator/aws_mp_configuration_schema.json
+++ b/charts/newrelic-k8s-operator/aws_mp_configuration_schema.json
@@ -1,19 +1,11 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "required": [
-        "global"
+        "newRelicLicenseKey"
     ],
     "properties": {
-        "global": {
-            "type": "object",
-            "required": [
-                "licenseKey"
-            ],
-            "properties": {
-                "licenseKey": {
-                    "type": "string"
-                }
-            }
-        }
+	"newRelicLicenseKey": {
+	    "type": "string"
+	}
     }
 }

--- a/charts/newrelic-k8s-operator/templates/secrets.yaml
+++ b/charts/newrelic-k8s-operator/templates/secrets.yaml
@@ -1,0 +1,10 @@
+{{if .Values.newRelicLicenseKey}}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: newrelic-secrets
+    namespace: {{.Release.Namespace}} 
+type: Opaque
+stringData:
+    license-key: {{.Values.newRelicLicenseKey}}
+{{- end}}

--- a/charts/newrelic-k8s-operator/values.yaml
+++ b/charts/newrelic-k8s-operator/values.yaml
@@ -1,4 +1,5 @@
 version: ""
+newRelicLicenseKey: ""
 newrelic-infrastructure:
   # newrelic-infrastructure.enabled -- Install the [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
   enabled: true
@@ -57,9 +58,9 @@ global:
   # -- The license key for your New Relic Account. This will be preferred configuration option if both `insightsKey` and `customSecret` are specified.
   insightsKey: ""
   # -- Name of the Secret object where the license key is stored
-  customSecretName: ""
+  customSecretName: "newrelic-secrets"
   # -- Key in the Secret object where the license key is stored
-  customSecretLicenseKey: ""
+  customSecretLicenseKey: "license-key"
 
   # -- Additional labels for chart objects
   labels: {}


### PR DESCRIPTION
Using `global.licenseKey` would result in the licenseKey to be stored unencrypted in the nribundle CRD.
Instead, users can now specify `newRelicLicenseKey`, which will be stored in a secret and used instead of `global.licenseKey`.

If both are specified, preference is given to `global.licenseKey`, as following the convention of `nribundle`.