### PR TITLE
Fix global.licenseKey secret

### DIFF
--- a/charts/newrelic-k8s-operator/Chart.yaml
+++ b/charts/newrelic-k8s-operator/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # time you make changes to the chart and its templates, including the app
 # version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the

--- a/charts/newrelic-k8s-operator/templates/secrets.yaml
+++ b/charts/newrelic-k8s-operator/templates/secrets.yaml
@@ -1,10 +1,13 @@
-{{if .Values.newRelicLicenseKey}}
 apiVersion: v1
 kind: Secret
 metadata:
     name: newrelic-secrets
-    namespace: {{.Release.Namespace}} 
+    namespace: {{.Release.Namespace}}
 type: Opaque
 stringData:
+{{ if .Values.global.licenseKey }}
+    license-key: {{ .Values.global.licenseKey }}
+{{- end }}
+{{ if and .Values.newRelicLicenseKey (not .Values.global.licenseKey) }}
     license-key: {{.Values.newRelicLicenseKey}}
 {{- end}}


### PR DESCRIPTION
After some testing, turns out that although documentation says global.licenseKey will be preferred over the custom license key secret, if the customLicenseKey secret name is specified that secret is still expected to exist.
