### PR TITLE
Update K8s Version in E2e Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ IMAGE_TAG_BASE ?= newrelic/newrelic-k8s-operator
 # Image URL to use all building/pushing image targets
 IMG ?= newrelic/newrelic-k8s-operator
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
+ENVTEST_K8S_VERSION = 1.27.5
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
## Which problem is this PR solving?

The K8s versions in E2e Tests are old.

## Short description of the changes

Check the GitHub workflows that run for PR pushes and:
Remove any references to Kubernetes versions 1.22 or older
Add to tests Kubernetes versions: 1.23.17, 1.24.17, 1.25.13, 1.26.8, 1.27.5

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## New Tests?


## Checklist:
- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Tests have been updated