### PR TITLE
feat: Sync versions between app image and Helm chart to ease customer inception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Sync versions between app image and Helm chart to ease customer inception by @juanjjaramillo in [#73](https://github.com/newrelic/newrelic-k8s-operator/pull/73)
+
 ## v0.1.0 - 2023-10-07
 
 ### 🚀 Enhancements


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
It is hard to track the mapping between `version` and `appVersion` on a Helm chart. By triggering a new image release, we are forcing that the next chart release will sync both versions to be the same.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
